### PR TITLE
Fixed minor bug in 'correct_for_large_boxes'

### DIFF
--- a/src/libs/pdb.py
+++ b/src/libs/pdb.py
@@ -113,7 +113,7 @@ class Nucleotide(object):
         
     def correct_for_large_boxes(self, box):
         for atom in self.atoms:
-            atom.shift(-np.rint(x.pos / box ) * box)
+            atom.shift(-np.rint(atom.pos / box ) * box)
 
     def to_pdb(self, chain_identifier, print_H, residue_serial, residue_suffix, residue_type):
         res = []


### PR DESCRIPTION
Just making this pull request to fix a minor bug I found when running oxDNA_PDB.py on the python3 branch.