### PR TITLE
Add oxView output option to cadnano script

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,9 @@ Treat different models as different strands
 
 ## cadnano-to-oxDNA converter
 
-The `cadnano_oxDNA.py` script converts [cadnano](https://cadnano.org/) files into oxDNA configurations. Note that the script **does not** support scaffold-less input files. It takes two mandatory arguments.
+The `cadnano_oxDNA.py` script converts [cadnano](https://cadnano.org/) files into oxDNA configurations. Optionally, it can also output [.oxview files](https://sulcgroup.github.io/oxdna-viewer/) which will contain additional information about base pairing, custom colors and clustered domains.
+
+Note that the script **does not** support scaffold-less input files. It takes two mandatory arguments.
 
 ### Mandatory arguments
 * The input cadnano file (in json format)
@@ -145,6 +147,8 @@ the length of the box side (in oxDNA simulation units) where the system will be 
 text file containing a valid DNA sequence (*e.g.* ATCTGA). If not specified, the sequence will be chosen randomly
 * `-p\--print-virt2-nuc`
 print the `virt2nuc` file that can be used by the oxDNA's `origami_utils.py` script to convert between cadnano and oxDNA nucleotide indexes
+* `-o\--print-oxview`
+print a `.oxview` file that can be opened and edited in oxView [.oxview](https://sulcgroup.github.io/oxdna-viewer/). Using this option will allow you to keep additional design information not included in the oxDNA files.
 
 ### Output
 * An oxDNA topology file (named by suffixing the cadnano file with ".top")

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ text file containing a valid DNA sequence (*e.g.* ATCTGA). If not specified, the
 * `-p\--print-virt2-nuc`
 print the `virt2nuc` file that can be used by the oxDNA's `origami_utils.py` script to convert between cadnano and oxDNA nucleotide indexes
 * `-o\--print-oxview`
-print a `.oxview` file that can be opened and edited in oxView [.oxview](https://sulcgroup.github.io/oxdna-viewer/). Using this option will allow you to keep additional design information not included in the oxDNA files.
+print a `.oxview` file that can be opened and edited in [oxView](https://sulcgroup.github.io/oxdna-viewer/). Using this option will allow you to keep additional design information not included in the oxDNA files.
 
 ### Output
 * An oxDNA topology file (named by suffixing the cadnano file with ".top")

--- a/src/cadnano_oxDNA.py
+++ b/src/cadnano_oxDNA.py
@@ -653,13 +653,13 @@ if __name__ == '__main__':
     def print_usage():
         print("USAGE:", file=sys.stderr)
         print("\t%s cadnano_file lattice_type" % sys.argv[0], file=sys.stderr)
-        print("\t[-q\--sequence FILE] [-b\--box VALUE] [-e\--seed VALUE] [-p\--print-virt2nuc] [-v\--print-oxview]", file=sys.stderr) 
+        print("\t[-q\--sequence FILE] [-b\--box VALUE] [-e\--seed VALUE] [-p\--print-virt2nuc] [-o\--print-oxview]", file=sys.stderr)
         exit(1)
         
     if len(sys.argv) < 3:
         print_usage()
         
-    shortArgs = 'q:b:e:p:v'
+    shortArgs = 'q:b:e:p:o'
     longArgs = ['sequence=', 'box=', 'seed=', 'print-virt2nuc', 'print-oxview']
     
     side = False
@@ -691,7 +691,7 @@ if __name__ == '__main__':
                 np.random.seed(int(k[1]))
             elif k[0] == '-p' or k[0] == "--print-virt2nuc":
                 print_virt2nuc = True
-            elif k[0] == '-v' or k[0] == "--print-oxview":
+            elif k[0] == '-o' or k[0] == "--print-oxview":
                 print_oxview = True
             
             

--- a/src/cadnano_oxDNA.py
+++ b/src/cadnano_oxDNA.py
@@ -653,18 +653,19 @@ if __name__ == '__main__':
     def print_usage():
         print("USAGE:", file=sys.stderr)
         print("\t%s cadnano_file lattice_type" % sys.argv[0], file=sys.stderr)
-        print("\t[-q\--sequence FILE] [-b\--box VALUE] [-e\--seed VALUE] [-p\--print-virt2nuc]", file=sys.stderr) 
+        print("\t[-q\--sequence FILE] [-b\--box VALUE] [-e\--seed VALUE] [-p\--print-virt2nuc] [-v\--print-oxview]", file=sys.stderr) 
         exit(1)
         
     if len(sys.argv) < 3:
         print_usage()
         
-    shortArgs = 'q:b:e:p'
-    longArgs = ['sequence=', 'box=', 'seed=', 'print-virt2nuc']
+    shortArgs = 'q:b:e:p:v'
+    longArgs = ['sequence=', 'box=', 'seed=', 'print-virt2nuc', 'print-oxview']
     
     side = False
     sequence_filename = False
     print_virt2nuc = False
+    print_oxview = False
     source_file = sys.argv[1]
     
     origami_sq = False
@@ -690,6 +691,8 @@ if __name__ == '__main__':
                 np.random.seed(int(k[1]))
             elif k[0] == '-p' or k[0] == "--print-virt2nuc":
                 print_virt2nuc = True
+            elif k[0] == '-v' or k[0] == "--print-oxview":
+                print_oxview = True
             
             
     except Exception:
@@ -1024,18 +1027,24 @@ if __name__ == '__main__':
         nnucs_to_here[strandii] = nuc_total
         nuc_total += len(strand._nucleotides)
 
+    id_to_helix = {}
     # fill in the _scaf and _stap dicts for the reverse vhelix_vbase_to_nucleotide object
     for vh, vb in list(vh_vb2nuc_final._scaf.keys()):
         strandii, nuciis = vh_vb2nuc_final._scaf[(vh, vb)]
         rev_nuciis = []
         for nucii in nuciis:
-            rev_nuciis.append(len(rev_sys._strands[strandii]._nucleotides) - 1 - (nucii - nnucs_to_here[strandii]) + nnucs_to_here[strandii])
+            nuc = len(rev_sys._strands[strandii]._nucleotides) - 1 - (nucii - nnucs_to_here[strandii]) + nnucs_to_here[strandii]
+            rev_nuciis.append(nuc)
+            id_to_helix[nuc] = (vh, vb)
         vh_vb2nuc_rev.add_scaf(vh, vb, strandii, rev_nuciis)
     for vh, vb in list(vh_vb2nuc_final._stap.keys()):
         strandii, nuciis = vh_vb2nuc_final._stap[(vh, vb)]
         rev_nuciis = []
         for nucii in nuciis:
-            rev_nuciis.append(len(rev_sys._strands[strandii]._nucleotides) - 1 - (nucii - nnucs_to_here[strandii]) + nnucs_to_here[strandii])
+            nuc = len(rev_sys._strands[strandii]._nucleotides) - 1 - (nucii - nnucs_to_here[strandii]) + nnucs_to_here[strandii]
+            rev_nuciis.append(nuc)
+            id_to_helix[nuc] = (vh, vb)
+
         vh_vb2nuc_rev.add_stap(vh, vb, strandii, rev_nuciis)
         
     # dump the spatial arrangement of the vhelices to a file
@@ -1055,6 +1064,9 @@ if __name__ == '__main__':
     basename = os.path.basename(sys.argv[1])
     topology_file = basename + ".top"
     configuration_file = basename + ".oxdna"
+
+    if print_oxview:
+        rev_sys.print_oxview_output(basename+'.oxview', id_to_helix)
     
     rev_sys.print_lorenzo_output(configuration_file, topology_file)
     

--- a/src/cadnano_oxDNA.py
+++ b/src/cadnano_oxDNA.py
@@ -1072,6 +1072,7 @@ if __name__ == '__main__':
             for c in vh.stap_colors:
                 vb, color = c
                 pos_to_color[(vh.num, vb)] = color
+
         # Create inverse mapping to find pairs by their positions
         pos_to_id = {}
         for bid, helix in id_to_pos.items():
@@ -1082,12 +1083,14 @@ if __name__ == '__main__':
 
         # Find the index of the scaffold strand (there really should be some
         # easier way of doing this)
-        strands = [id_to_nucleotide[j].strand for i in pos_to_id.values() for j in i]
+        strands = [id_to_nucleotide[nucId].strand for nucIds in pos_to_id.values() for nucId in nucIds]
         scaffold_index = max(set(strands), key=strands.count)
 
         # Make one cluster per domain
         cluster_ids = {}
 
+        # Go through system and add extra information
+        # (basepairs, clusters and colors)
         for s in rev_sys._strands:
             for n in s._nucleotides:
                 if n.index in id_to_pos:
@@ -1119,6 +1122,8 @@ if __name__ == '__main__':
                     for other in s._nucleotides:
                         other.color = n.color
                     break
+
+        # Print the oxview output
         rev_sys.print_oxview_output(basename+'.oxview')
 
     rev_sys.print_lorenzo_output(configuration_file, topology_file)


### PR DESCRIPTION
Add the possibility to get an .oxview file from the cadnano-to-oxDNA conversion script. This includes extra information that cannot be saved in the native oxDNA format:

- Basepairing info (which you can use to create a pair trap file)
- Custom coloring (to mark a strand in caDNAno and find it in oxView)
- Cluster by domain (to select and move things around easier)

Drag and drop into https://sulcgroup.github.io/oxdna-viewer/  