### PR TITLE
Read NUMBER OF ATOMS and BOX BOUNDS at every checkpoint

### DIFF
--- a/src/LAMMPS_oxDNA.py
+++ b/src/LAMMPS_oxDNA.py
@@ -92,7 +92,9 @@ if __name__ == '__main__':
             
                 if line.startswith('ITEM: NUMBER OF ATOMS'):
                     natoms = int(lmptrj.readline())
-            
+                    if natoms != conf.natoms:
+                        print("ERROR: A configuration stored in the trajectory file contains a number of nucleotides %d that differs from the %d in the datafile" % \
+                          (natoms, conf.natoms), file=sys.stderr)            
                 if line.startswith('ITEM: BOX BOUNDS'):
                     line = lmptrj.readline()
                     xlo, xhi = np.float32(line.split()[0]), np.float32(line.split()[1])
@@ -154,7 +156,8 @@ if __name__ == '__main__':
                         v = np.array(vel[n,:]) * np.sqrt(mass_in_lammps)
                         Lv = np.array(angmom[n,:]) / np.sqrt(inertia_in_lammps)
             
-                        oxconf.write('%le %le %le %le %le %le %le %le %le %le %le %le %le %le %le \n' % (cm[0], cm[1], cm[2], a1[0], a1[1], a1[2], a3[0], a3[1], a3[2], v[0], v[1], v[2], Lv[0], Lv[1], Lv[2]))
+                        oxconf.write('%le %le %le %le %le %le %le %le %le %le %le %le %le %le %le \n' % \
+                          (cm[0], cm[1], cm[2], a1[0], a1[1], a1[2], a3[0], a3[1], a3[2], v[0], v[1], v[2], Lv[0], Lv[1], Lv[2]))
             
                 line = lmptrj.readline()
 

--- a/src/LAMMPS_oxDNA.py
+++ b/src/LAMMPS_oxDNA.py
@@ -90,10 +90,10 @@ if __name__ == '__main__':
                 if line.startswith('ITEM: TIMESTEP'):
                     t = int(lmptrj.readline())
             
-                if line.startswith('ITEM: NUMBER OF ATOMS') and t == 0:
+                if line.startswith('ITEM: NUMBER OF ATOMS'):
                     natoms = int(lmptrj.readline())
             
-                if line.startswith('ITEM: BOX BOUNDS') and t == 0:
+                if line.startswith('ITEM: BOX BOUNDS'):
                     line = lmptrj.readline()
                     xlo, xhi = np.float32(line.split()[0]), np.float32(line.split()[1])
                     Lx = xhi - xlo

--- a/src/LAMMPS_oxDNA.py
+++ b/src/LAMMPS_oxDNA.py
@@ -95,7 +95,7 @@ if __name__ == '__main__':
                     if natoms != conf.natoms:
                         print("ERROR: A configuration stored in the trajectory file contains a number of nucleotides %d that differs from the %d in the datafile" % \
                           (natoms, conf.natoms), file=sys.stderr)            
-
+                        sys.exit(1)
                 if line.startswith('ITEM: BOX BOUNDS'):
                     line = lmptrj.readline()
                     xlo, xhi = np.float32(line.split()[0]), np.float32(line.split()[1])

--- a/src/LAMMPS_oxDNA.py
+++ b/src/LAMMPS_oxDNA.py
@@ -95,6 +95,7 @@ if __name__ == '__main__':
                     if natoms != conf.natoms:
                         print("ERROR: A configuration stored in the trajectory file contains a number of nucleotides %d that differs from the %d in the datafile" % \
                           (natoms, conf.natoms), file=sys.stderr)            
+
                 if line.startswith('ITEM: BOX BOUNDS'):
                     line = lmptrj.readline()
                     xlo, xhi = np.float32(line.split()[0]), np.float32(line.split()[1])


### PR DESCRIPTION
Hi Lorenzo,

The script threw an error when the first timestep in the trajectory file wasn't t=0 as NUMBER OF ATOMS and BOX BOUND weren't set then.

I modified the code to read NUMBER OF ATOMS and BOX BOUNDS at every timestep. There is virtually no impact on performance and conversion of trajectory files is now also possible when the first timestep is not zero.

Pull request for python2 comes in a moment.

Cheers,
O