### PR TITLE
Bug fix: open file in "wb" mode when print_virt2nuc in `cadnano_oxDNA.py`

### DIFF
--- a/src/cadnano_oxDNA.py
+++ b/src/cadnano_oxDNA.py
@@ -1057,7 +1057,7 @@ if __name__ == '__main__':
         exit(1)
 
     if print_virt2nuc:
-        with open("virt2nuc", "w") as fout:
+        with open("virt2nuc", "wb") as fout:
             pickle.dump((vh_vb2nuc_rev, vhelix_pattern), fout)
             print("## Wrote nucleotides' index conversion data to virt2nuc", file=sys.stderr)
 


### PR DESCRIPTION
The original code gives the following error when enabling the `-p` flag. 

```
Traceback (most recent call last):
  File "D:\PycharmProjects\tacoxDNA\src\cadnano_oxDNA.py", line 1061, in <module>
    pickle.dump((vh_vb2nuc_rev, vhelix_pattern), fout)
TypeError: write() argument must be str, not bytes
```

Not sure if this is outdated, but I guess the output is fed into this file: https://github.com/mckwxp/oxDNA_UTILS/blob/master/origami_utils.py